### PR TITLE
Dockerise generation of aws ssh config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3
+
+WORKDIR /app
+
+COPY requirements.txt ./
+
+RUN pip install -r requirements.txt --no-cache
+
+ARG USER_ID=1000
+ARG USER_GROUP_ID=1000
+
+RUN groupadd -g ${USER_GROUP_ID} appuser && useradd -r -u ${USER_ID} -g appuser -m -d /home/appuser appuser
+USER appuser
+
+COPY *.py ./

--- a/README.md
+++ b/README.md
@@ -46,11 +46,21 @@ and add the following to the top of your `~/.ssh/config`
 
 Add this to your .bashrc:
   ```Ini
-    alias reconf="~/projects/ansible_aws_inventory/aws_inventory.py -c ~/.ssh/aws_config --clear"
+    alias reconf="cd /<full-path-to>/ansible_aws_inventory/ && ./reconf.sh"
     alias hosts="grep ^Host ~/.ssh/aws_config"
   ```
 
 The first command regenerates ssh config. The second one lists all available hosts.
+
+To refresh ssh config automatically you shall create a cron entry in `/etc/cron.d/aws_reconf`
+```bash
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=""
+
+# m h dom mon dow user	command
+51 9 * * * root su <your_user> -c "cd /<full-path-to>/ansible_aws_inventory/ && ./reconf.sh"
+``` 
 
 Enjoy!
 

--- a/reconf.sh
+++ b/reconf.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [ ! -f "${HOME}/.ssh/aws_config" ] ; then
+    touch "${HOME}/.ssh/aws_config"
+fi;
+
+docker run --rm -v "${HOME}/.aws/config":/home/appuser/.aws/config:ro \
+    -v "${HOME}/.aws/credentials":/home/appuser/.aws/credentials:ro \
+    -v "${HOME}/.ssh/aws_config":/app/aws_config \
+    $(docker build -q . --tag "ansible_aws_inventory" --build-arg USER_ID=$(id -u) --build-arg USER_GROUP_ID=$(id -g)) \
+    ./aws_inventory.py -c /app/aws_config --clear


### PR DESCRIPTION
I have a new rule on my new laptop **All project environments in docker**
I realize to refresh aws config I would have to mess up my system python packages or create a virtual environment. So I created a docker for the task.
I'm open to ideas for this to get merge. 

TODO:
- [ ] I haven't explored a way to use docker as an inventory for ansible as I don't run ansible from my laptop.